### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,12 +1,12 @@
 # Datatypes (KEYWORD1)
 
 # Methods and Functions (KEYWORD2)
-read KEYWORD2
-getInternal KEYWORD2
-getExternal KEYWORD2
-isShortedToVcc() KEYWORD2
-isShortedToGnd() KEYWORD2
-isOpen() KEYWORD2
-hasError() KEYWORD2
+read	KEYWORD2
+getInternal	KEYWORD2
+getExternal	KEYWORD2
+isShortedToVcc()	KEYWORD2
+isShortedToGnd()	KEYWORD2
+isOpen()	KEYWORD2
+hasError()	KEYWORD2
 
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords